### PR TITLE
Avoid javascript errors and use invariant culture to avoid formating error...

### DIFF
--- a/Actors/VisualObjects/VisualObjects.Common/Color.cs
+++ b/Actors/VisualObjects/VisualObjects.Common/Color.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System.Globalization;
+
 namespace VisualObjects.Common
 {
     using System;
@@ -82,10 +84,10 @@ namespace VisualObjects.Common
         {
             builder.AppendFormat(
                 "{{ \"r\":{0}, \"g\":{1}, \"b\":{2}, \"a\":{3} }}",
-                this.R,
-                this.G,
-                this.B,
-                this.A);
+                this.R.ToString(NumberFormatInfo.InvariantInfo),
+                this.G.ToString(NumberFormatInfo.InvariantInfo),
+                this.B.ToString(NumberFormatInfo.InvariantInfo),
+                this.A.ToString(NumberFormatInfo.InvariantInfo));
         }
     }
 }

--- a/Actors/VisualObjects/VisualObjects.Common/Coordinate.cs
+++ b/Actors/VisualObjects/VisualObjects.Common/Coordinate.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System.Globalization;
+
 namespace VisualObjects.Common
 {
     using System;
@@ -57,9 +59,9 @@ namespace VisualObjects.Common
         {
             builder.AppendFormat(
                 "{{ \"x\":{0}, \"y\":{1}, \"z\":{2} }}",
-                this.X,
-                this.Y,
-                this.Z);
+                this.X.ToString(NumberFormatInfo.InvariantInfo),
+                this.Y.ToString(NumberFormatInfo.InvariantInfo),
+                this.Z.ToString(NumberFormatInfo.InvariantInfo));
         }
     }
 }

--- a/Actors/VisualObjects/VisualObjects.WebService/VisualObjects.WebService.csproj
+++ b/Actors/VisualObjects/VisualObjects.WebService/VisualObjects.WebService.csproj
@@ -113,13 +113,13 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="wwwroot\Scripts\visualobjects.js">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="wwwroot\Scripts\gl-matrix-min.js">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="wwwroot\Scripts\webgl-utils.js">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="wwwroot\Index.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Actors/VisualObjects/VisualObjects.WebService/wwwroot/Index.html
+++ b/Actors/VisualObjects/VisualObjects.WebService/wwwroot/Index.html
@@ -1,4 +1,5 @@
-﻿<html>
+﻿<!DOCTYPE html>
+<html>
     <head>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Windows Fabric Visual Objects Demo</title>

--- a/Actors/VisualObjects/VisualObjects.WebService/wwwroot/Index.html
+++ b/Actors/VisualObjects/VisualObjects.WebService/wwwroot/Index.html
@@ -1,4 +1,3 @@
-﻿<!DOCTYPE html>
 <html>
     <head>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/Actors/VisualObjects/VisualObjects.WebService/wwwroot/Scripts/visualobjects.js
+++ b/Actors/VisualObjects/VisualObjects.WebService/wwwroot/Scripts/visualobjects.js
@@ -143,6 +143,9 @@ var yRotate = 0;
 var zRotate = 0;
 
 function handleKeys() {
+    if (currentlyPressedKeys == undefined) {
+        return;
+    }
     if (currentlyPressedKeys[33]) {
         if (currentlyPressedKeys[32]) {
             // Ctrl
@@ -321,9 +324,13 @@ function updateNodeBuffersToRender() {
 }
 
 function drawScene() {
+    if (mat4 == undefined) {
+        return;
+    }
+
     gl.viewport(0, 0, gl.viewportWidth, gl.viewportHeight);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-
+    
     mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix);
 
     mat4.identity(mvMatrix);


### PR DESCRIPTION
visualobjects.js:  2 patchs to avoid a lot of javascript errors !!
Color.cs and Coordinate.cs: use invariant culture to avoid error due to culture formating ie french decimal separator :-)
Index.html: Add <!DOCTYPE html> to avoid warning from the developer's console
VisualObjects.WebService.csproj: change CopyToOutpuDirectory Always by security.
Works well ! http://i.imgur.com/eun8UND.png