### PR TITLE
VisualObject/Move: properly zeroing rotation speed

### DIFF
--- a/Actors/VisualObjects/VisualObjects.Common/VisualObject.cs
+++ b/Actors/VisualObjects/VisualObjects.Common/VisualObject.cs
@@ -117,6 +117,10 @@ namespace VisualObjects.Common
             {
                 this.Rotation = 5;
             }
+            else
+            {
+                this.Rotation = 0;
+            }
         }
 
         public string ToJson()


### PR DESCRIPTION
Once rotating, VisualObject stays rotating forever despite `visualObject.Move(false);`.