### PR TITLE
added retry logic that demonstrates interaction with service partition resolver

### DIFF
--- a/Services/AlphabetPartitions/AlphabetPartitions/AlphabetPartitions.sfproj
+++ b/Services/AlphabetPartitions/AlphabetPartitions/AlphabetPartitions.sfproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.2.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.2.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.4.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.4.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>ac80cdb2-9dd0-4cfc-91bd-f8449c83295f</ProjectGuid>
-    <ProjectVersion>1.2</ProjectVersion>
+    <ProjectVersion>1.4</ProjectVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -37,5 +37,5 @@
     <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
   </PropertyGroup>
   <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.2.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.2.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.4.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.4.0\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
 </Project>

--- a/Services/AlphabetPartitions/AlphabetPartitions/Scripts/Deploy-FabricApplication.ps1
+++ b/Services/AlphabetPartitions/AlphabetPartitions/Scripts/Deploy-FabricApplication.ps1
@@ -25,7 +25,7 @@ Indicates whether to unregister any unused application versions that exist after
 
 .PARAMETER OverrideUpgradeBehavior
 Indicates the behavior used to override the upgrade settings specified by the publish profile.
-'None' indicates that the upgrade settings will not be overriden.
+'None' indicates that the upgrade settings will not be overridden.
 'ForceUpgrade' indicates that an upgrade will occur with default settings, regardless of what is specified in the publish profile.
 'VetoUpgrade' indicates that an upgrade will not occur, regardless of what is specified in the publish profile.
 
@@ -43,6 +43,9 @@ Switch signaling whether the package should be validated or not before deploymen
 
 .PARAMETER SecurityToken
 A security token for authentication to cluster management endpoints. Used for silent authentication to clusters that are protected by Azure Active Directory.
+
+.PARAMETER CopyPackageTimeoutSec
+Timeout in seconds for copying application package to image store.
 
 .EXAMPLE
 . Scripts\Deploy-FabricApplication.ps1 -ApplicationPackagePath 'pkg\Debug'
@@ -92,7 +95,10 @@ Param
     $SkipPackageValidation,
 
     [String]
-    $SecurityToken 
+    $SecurityToken,
+
+    [int]
+    $CopyPackageTimeoutSec
 )
 
 function Read-XmlElementAsHashtable
@@ -206,7 +212,14 @@ if ($IsUpgrade)
         $UpgradeParameters = @{ UnmonitoredAuto = $true; Force = $true }
     }
 
-    Publish-UpgradedServiceFabricApplication -ApplicationPackagePath $ApplicationPackagePath -ApplicationParameterFilePath $publishProfile.ApplicationParameterFile -Action $Action -UpgradeParameters $UpgradeParameters -ApplicationParameter $ApplicationParameter -UnregisterUnusedVersions:$UnregisterUnusedApplicationVersionsAfterUpgrade -ErrorAction Stop
+    if ($CopyPackageTimeoutSec)
+    {
+        Publish-UpgradedServiceFabricApplication -ApplicationPackagePath $ApplicationPackagePath -ApplicationParameterFilePath $publishProfile.ApplicationParameterFile -Action $Action -UpgradeParameters $UpgradeParameters -ApplicationParameter $ApplicationParameter -UnregisterUnusedVersions:$UnregisterUnusedApplicationVersionsAfterUpgrade -CopyPackageTimeoutSec $CopyPackageTimeoutSec -ErrorAction Stop
+    }
+    else
+    {
+        Publish-UpgradedServiceFabricApplication -ApplicationPackagePath $ApplicationPackagePath -ApplicationParameterFilePath $publishProfile.ApplicationParameterFile -Action $Action -UpgradeParameters $UpgradeParameters -ApplicationParameter $ApplicationParameter -UnregisterUnusedVersions:$UnregisterUnusedApplicationVersionsAfterUpgrade -ErrorAction Stop
+    }
 }
 else
 {
@@ -216,5 +229,12 @@ else
         $Action = "Register"
     }
     
-    Publish-NewServiceFabricApplication -ApplicationPackagePath $ApplicationPackagePath -ApplicationParameterFilePath $publishProfile.ApplicationParameterFile -Action $Action -ApplicationParameter $ApplicationParameter -OverwriteBehavior $OverwriteBehavior -SkipPackageValidation:$SkipPackageValidation -ErrorAction Stop
+    if ($CopyPackageTimeoutSec)
+    {
+        Publish-NewServiceFabricApplication -ApplicationPackagePath $ApplicationPackagePath -ApplicationParameterFilePath $publishProfile.ApplicationParameterFile -Action $Action -ApplicationParameter $ApplicationParameter -OverwriteBehavior $OverwriteBehavior -SkipPackageValidation:$SkipPackageValidation -CopyPackageTimeoutSec $CopyPackageTimeoutSec -ErrorAction Stop
+    }
+    else
+    {
+        Publish-NewServiceFabricApplication -ApplicationPackagePath $ApplicationPackagePath -ApplicationParameterFilePath $publishProfile.ApplicationParameterFile -Action $Action -ApplicationParameter $ApplicationParameter -OverwriteBehavior $OverwriteBehavior -SkipPackageValidation:$SkipPackageValidation -ErrorAction Stop
+    }
 }

--- a/Services/AlphabetPartitions/AlphabetPartitions/packages.config
+++ b/Services/AlphabetPartitions/AlphabetPartitions/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.2.0" />
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.4.0" />
 </packages>


### PR DESCRIPTION
Updated the logic in Web.cs to mention that the service partition resolver will provide results based on cached data. This retry demonstration shows how to ask the partition service to provide a new result after receiving a 503 when we try to communicate to the Processing service.