### PR TITLE
Fixed platform target settings for Release builds.

### DIFF
--- a/src/GettingStartedApplication/StatefulBackendService/StatefulBackendService.csproj
+++ b/src/GettingStartedApplication/StatefulBackendService/StatefulBackendService.csproj
@@ -12,6 +12,10 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="App.config" />
     <None Update="Views;Areas\**\Views">

--- a/src/GettingStartedApplication/WebService/WebService.csproj
+++ b/src/GettingStartedApplication/WebService/WebService.csproj
@@ -12,6 +12,10 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="App.config" />
     <None Update="wwwroot\**\*;Views\**\*;Areas\**\Views">


### PR DESCRIPTION
This fixes the Release build settings for the WebService and StatefulBackendService projects. These are currently are set to x86, which causes "MSB3270: There was a mismatch between the processor architecture of the project being built "x86" and the processor architecture of the reference. [...]  "AMD64". 